### PR TITLE
Feat/db

### DIFF
--- a/lib/view/auth/auth_screen.dart
+++ b/lib/view/auth/auth_screen.dart
@@ -45,7 +45,7 @@ class _AuthScreenState extends State<AuthScreen> {
         builder: (context, vm, _) {
           return PopScope(
             canPop: false,
-            onPopInvoked: (didPop) async {
+            onPopInvokedWithResult: (bool didPop, dynamic result) async {
               if (didPop) return;
 
               if (_currentPage == 0) {
@@ -63,13 +63,7 @@ class _AuthScreenState extends State<AuthScreen> {
                 children: [
                   SelectTeamView(onNext: _nextPage),
                   NicknameInputView(onNext: _nextPage, onBack: _previousPage),
-                  WelcomeView(
-                    onNext:
-                        () => Navigator.pushReplacementNamed(
-                          context,
-                          Routes.main,
-                        ),
-                  ),
+                  WelcomeView(onNext: () => Navigator.pushReplacementNamed(context, Routes.main)),
                 ],
               ),
             ),

--- a/lib/view/auth/widgets/components/team_button.dart
+++ b/lib/view/auth/widgets/components/team_button.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:seungyo/constants/team_data.dart';
+import 'package:seungyo/theme/app_colors.dart';
+import 'package:seungyo/theme/app_text_styles.dart';
 
 /// 팀 선택 화면에서 사용하는 팀 버튼 컴포넌트
 ///
 /// 사용자가 응원하는 팀을 선택할 수 있는 원형 버튼을 제공합니다.
-/// 선택된 팀은 강조 색상과 밑줄로 표시됩니다.
+/// 선택된 팀은 강조 색상과 텍스트로 표시됩니다.
 ///
 /// [team]은 표시할 팀 정보, [isSelected]는 선택 상태, [onTap]은 클릭 이벤트 핸들러입니다.
 class TeamButton extends StatelessWidget {
@@ -18,54 +20,22 @@ class TeamButton extends StatelessWidget {
   final VoidCallback onTap;
 
   /// 버튼 최대 크기
-  static const double maxSize = 100.0;
-
-  /// 팀 이름 밑줄 높이
-  static const double _underlineHeight = 10.0;
+  static const double maxSize = 85.0;
 
   /// 팀 이름과 아이콘 사이 간격
-  static const double _verticalSpacing = 6.0;
+  static const double _verticalSpacing = 8.0;
 
-  const TeamButton({
-    super.key,
-    required this.team,
-    required this.isSelected,
-    required this.onTap,
-  });
+  const TeamButton({super.key, required this.team, required this.isSelected, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final textTheme = theme.textTheme;
-
     return LayoutBuilder(
       builder: (context, constraints) {
         final availableWidth = constraints.maxWidth;
         // 너비가 충분하지 않으면 가용 너비를 사용
         final size = availableWidth > maxSize ? maxSize : availableWidth;
-
-        // 팀 이름 텍스트 스타일
-        final textStyle =
-            isSelected
-                ? textTheme.bodyLarge?.copyWith(
-                  color: colorScheme.primary,
-                  height: 1.1,
-                  fontWeight: FontWeight.bold,
-                )
-                : textTheme.bodyMedium?.copyWith(
-                  color: colorScheme.onSurface,
-                  height: 1.1,
-                );
-
-        // 원형 배경 스타일
-        final circleBackground =
-            isSelected ? colorScheme.secondary : colorScheme.surfaceContainer;
-
-        // 테두리 스타일
-        final borderColor =
-            isSelected ? colorScheme.primary : colorScheme.outline;
-        final borderWidth = isSelected ? 2.0 : 1.0;
+        // 텍스트 너비는 버튼보다 20% 더 넓게 설정
+        final textWidth = size * 1.2;
 
         return GestureDetector(
           onTap: onTap,
@@ -77,15 +47,18 @@ class TeamButton extends StatelessWidget {
                 width: size,
                 height: size,
                 decoration: BoxDecoration(
-                  color: circleBackground,
+                  color: isSelected ? AppColors.mint50 : AppColors.navy5,
                   shape: BoxShape.circle,
-                  border: Border.all(color: borderColor, width: borderWidth),
+                  border: Border.all(
+                    color: isSelected ? AppColors.navy : AppColors.gray30,
+                    width: isSelected ? 2.0 : 1.0,
+                  ),
                 ),
                 child: Center(
-                  child: Image.asset(
-                    team.emblem,
-                    fit: BoxFit.none,
-                    semanticLabel: '${team.name} 팀 엠블럼',
+                  // 이미지 크기를 조정하여 깔끔하게 표시
+                  child: Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Image.asset(team.emblem, fit: BoxFit.contain, semanticLabel: '${team.name} 팀 엠블럼'),
                   ),
                 ),
               ),
@@ -93,35 +66,18 @@ class TeamButton extends StatelessWidget {
               SizedBox(height: _verticalSpacing),
 
               // 팀 이름
-              SizedBox(
-                width: size,
-                height: 20,
-                child: Stack(
-                  alignment: Alignment.center,
-                  children: [
-                    // 선택 표시용 밑줄 (선택된 경우)
-                    if (isSelected)
-                      Positioned(
-                        bottom: 0,
-                        child: Container(
-                          width: size * 0.8, // 팀 이름 너비의 80%
-                          height: _underlineHeight,
-                          decoration: BoxDecoration(
-                            color: colorScheme.secondary,
-                            borderRadius: BorderRadius.circular(2),
-                          ),
-                        ),
-                      ),
-
-                    // 팀 이름 텍스트
-                    Text(
-                      team.name,
-                      style: textStyle,
-                      textAlign: TextAlign.center,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
+              Container(
+                width: textWidth,
+                height: 22, // 높이를 고정하여 텍스트가 짤리지 않도록 함
+                child: Text(
+                  team.name,
+                  style:
+                      isSelected
+                          ? AppTextStyles.body1.copyWith(color: AppColors.navy)
+                          : AppTextStyles.body3.copyWith(color: AppColors.black),
+                  textAlign: TextAlign.center,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
             ],

--- a/lib/view/auth/widgets/nickname_input_view.dart
+++ b/lib/view/auth/widgets/nickname_input_view.dart
@@ -6,11 +6,7 @@ class NicknameInputView extends StatefulWidget {
   final VoidCallback onNext;
   final VoidCallback onBack;
 
-  const NicknameInputView({
-    super.key,
-    required this.onNext,
-    required this.onBack,
-  });
+  const NicknameInputView({super.key, required this.onNext, required this.onBack});
 
   @override
   State<NicknameInputView> createState() => _NicknameInputViewState();
@@ -44,7 +40,7 @@ class _NicknameInputViewState extends State<NicknameInputView> {
 
     return PopScope(
       canPop: false,
-      onPopInvoked: (didPop) {
+      onPopInvokedWithResult: (bool didPop, dynamic result) {
         if (!didPop) {
           FocusScope.of(context).unfocus();
           widget.onBack();
@@ -103,9 +99,7 @@ class _NicknameInputViewState extends State<NicknameInputView> {
                       widget.onNext();
                     }
                     : null,
-            style: ElevatedButton.styleFrom(
-              minimumSize: const Size.fromHeight(48),
-            ),
+            style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(48)),
             child: const Text('등록 완료'),
           ),
         ),

--- a/lib/view/auth/widgets/nickname_input_view.dart
+++ b/lib/view/auth/widgets/nickname_input_view.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:seungyo/constants/team_data.dart';
+import 'package:seungyo/theme/app_colors.dart';
+import 'package:seungyo/theme/app_text_styles.dart';
 import 'package:seungyo/viewmodel/auth_vm.dart';
 
 class NicknameInputView extends StatefulWidget {
@@ -14,22 +17,52 @@ class NicknameInputView extends StatefulWidget {
 
 class _NicknameInputViewState extends State<NicknameInputView> {
   final TextEditingController _controller = TextEditingController();
-  String? errorText;
+  bool isTextFieldFocused = false;
+  FocusNode focusNode = FocusNode();
+
+  // 닉네임 최소/최대 길이 제한
+  static const int _minLength = 2;
+  static const int _maxLength = 10;
+
+  // 닉네임 유효성 상태
+  String? _validationMessage;
+  bool _isValid = false;
 
   @override
   void initState() {
     super.initState();
     _controller.addListener(_onTextChanged);
+    focusNode.addListener(() {
+      setState(() {
+        isTextFieldFocused = focusNode.hasFocus;
+      });
+    });
   }
 
   void _onTextChanged() {
-    setState(() {});
+    final text = _controller.text.trim();
+    final length = text.length;
+
+    setState(() {
+      // 닉네임 유효성 검사
+      if (length < _minLength) {
+        _validationMessage = null; // 2글자 미만이면 메시지 표시 안함
+        _isValid = false;
+      } else if (length > _maxLength) {
+        _validationMessage = "닉네임은 최대 ${_maxLength}글자까지 가능해요.";
+        _isValid = false;
+      } else {
+        _validationMessage = "사용 가능한 닉네임이에요.";
+        _isValid = true;
+      }
+    });
   }
 
   @override
   void dispose() {
     _controller.removeListener(_onTextChanged);
     _controller.dispose();
+    focusNode.dispose();
     super.dispose();
   }
 
@@ -37,6 +70,7 @@ class _NicknameInputViewState extends State<NicknameInputView> {
   Widget build(BuildContext context) {
     final vm = context.watch<AuthViewModel>();
     final team = vm.team ?? '';
+    final teamName = vm.teamName ?? '';
 
     return PopScope(
       canPop: false,
@@ -48,11 +82,12 @@ class _NicknameInputViewState extends State<NicknameInputView> {
       },
       child: Scaffold(
         resizeToAvoidBottomInset: false,
+        backgroundColor: Colors.white,
         appBar: AppBar(
-          title: const Text('정보입력'),
+          title: const Text('정보 입력', style: AppTextStyles.subtitle1),
           centerTitle: true,
           backgroundColor: Colors.white,
-          foregroundColor: Colors.black,
+          foregroundColor: AppColors.black,
           elevation: 0,
           leading: IconButton(
             icon: const Icon(Icons.arrow_back),
@@ -63,44 +98,160 @@ class _NicknameInputViewState extends State<NicknameInputView> {
           ),
         ),
         body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(16, 40, 16, 100),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                const SizedBox(height: 15),
-                Text(
-                  team.isNotEmpty ? '$team 승요의\n닉네임을 입력해주세요.' : '닉네임을 입력해주세요.',
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(fontSize: 18),
-                ),
-                const SizedBox(height: 15),
-                TextField(
-                  controller: _controller,
-                  decoration: InputDecoration(
-                    hintText: '닉네임 입력',
-                    border: const OutlineInputBorder(),
-                    errorText: errorText,
+          child: Column(
+            children: [
+              // 상단 컨텐츠 영역
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.all(40.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      // 팀 로고 이미지 (원형 프레임 안에)
+                      if (team.isNotEmpty)
+                        Container(
+                          width: 100,
+                          height: 100,
+                          decoration: BoxDecoration(
+                            color: AppColors.navy5,
+                            shape: BoxShape.circle,
+                            border: Border.all(color: AppColors.gray30, width: 1),
+                          ),
+                          child: ClipOval(
+                            child: Padding(
+                              padding: const EdgeInsets.all(20.0),
+                              child: Image.asset(TeamData.getByCode(team)?.emblem ?? '', fit: BoxFit.contain),
+                            ),
+                          ),
+                        ),
+                      const SizedBox(height: 15),
+
+                      // 타이틀 텍스트
+                      Text(
+                        teamName.isNotEmpty ? '$teamName 승요의\n닉네임을 입력해주세요.' : '닉네임을 입력해주세요.',
+                        textAlign: TextAlign.center,
+                        style: AppTextStyles.h3.copyWith(color: AppColors.navy),
+                      ),
+                      const SizedBox(height: 30),
+
+                      // 닉네임 입력 필드
+                      Container(
+                        height: 56,
+                        decoration: BoxDecoration(
+                          color: AppColors.navy5,
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(color: isTextFieldFocused ? AppColors.navy : AppColors.gray30, width: 1),
+                        ),
+                        child: Center(
+                          child: TextField(
+                            controller: _controller,
+                            focusNode: focusNode,
+                            textAlign: TextAlign.center,
+                            style: AppTextStyles.body2,
+                            maxLength: _maxLength,
+                            // 최대 글자 수 제한
+                            buildCounter: (context, {required currentLength, required isFocused, maxLength}) => null,
+                            // 카운터 숨기기
+                            decoration: InputDecoration(
+                              hintText: 'ex. 두산승리요정',
+                              hintStyle: AppTextStyles.body2.copyWith(color: AppColors.gray50),
+                              border: InputBorder.none,
+                              contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                            ),
+                          ),
+                        ),
+                      ),
+
+                      // 닉네임 유효성 메시지 (텍스트 길이가 최소 길이 이상일 때만 표시)
+                      if (_controller.text.trim().length >= _minLength)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 10),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              // 체크 아이콘 또는 경고 아이콘
+                              Container(
+                                width: 16,
+                                height: 16,
+                                decoration: BoxDecoration(
+                                  color: _isValid ? AppColors.positiveBG : AppColors.negativeBG,
+                                  shape: BoxShape.circle,
+                                ),
+                                child: Center(
+                                  child: Icon(
+                                    _isValid ? Icons.check : Icons.close,
+                                    size: 12,
+                                    color: _isValid ? AppColors.positive : AppColors.negative,
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: 4),
+                              // 메시지 텍스트
+                              Text(
+                                _validationMessage ?? '',
+                                style: AppTextStyles.caption.copyWith(
+                                  color: _isValid ? AppColors.positive : AppColors.negative,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                    ],
                   ),
                 ),
-              ],
-            ),
-          ),
-        ),
-        bottomNavigationBar: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 0, 16, 28),
-          child: ElevatedButton(
-            onPressed:
-                _controller.text.trim().isNotEmpty
-                    ? () async {
-                      FocusScope.of(context).unfocus();
-                      vm.setNickname(_controller.text.trim());
-                      await vm.saveUserInfo();
-                      widget.onNext();
-                    }
-                    : null,
-            style: ElevatedButton.styleFrom(minimumSize: const Size.fromHeight(48)),
-            child: const Text('등록 완료'),
+              ),
+
+              // 하단 버튼 영역
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+                child: Column(
+                  children: [
+                    // 등록 완료 버튼
+                    Container(
+                      width: double.infinity,
+                      height: 56,
+                      child: TextButton(
+                        onPressed:
+                            _controller.text.trim().length >= _minLength && _controller.text.trim().length <= _maxLength
+                                ? () async {
+                                  FocusScope.of(context).unfocus();
+                                  vm.setNickname(_controller.text.trim());
+                                  await vm.saveUserInfo();
+                                  widget.onNext();
+                                }
+                                : null,
+                        style: TextButton.styleFrom(
+                          backgroundColor:
+                              _isValid
+                                  ? AppColors
+                                      .navy // 유효하면 네이비 색상
+                                  : AppColors.navy5,
+                          // 유효하지 않으면 연한 회색
+                          foregroundColor:
+                              _isValid
+                                  ? Colors
+                                      .white // 유효하면 흰색 텍스트
+                                  : AppColors.navy30,
+                          // 유효하지 않으면 연한 네이비 텍스트
+                          disabledForegroundColor: AppColors.navy30,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                          padding: EdgeInsets.zero,
+                        ),
+                        child: Text('등록 완료', style: AppTextStyles.subtitle2),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+
+                    // iOS 홈 인디케이터
+                    Container(
+                      width: 134,
+                      height: 5,
+                      decoration: BoxDecoration(color: Colors.black, borderRadius: BorderRadius.circular(100)),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/view/auth/widgets/select_team_view.dart
+++ b/lib/view/auth/widgets/select_team_view.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:seungyo/constants/team_data.dart';
-import 'package:seungyo/components/primary_button.dart';
-import 'package:seungyo/components/title_header.dart';
+import 'package:seungyo/theme/app_colors.dart';
+import 'package:seungyo/theme/app_text_styles.dart';
 import 'package:seungyo/view/auth/widgets/components/team_button.dart';
 import 'package:seungyo/viewmodel/auth_vm.dart';
 
@@ -22,26 +22,28 @@ class SelectTeamView extends StatefulWidget {
 
 class _SelectTeamViewState extends State<SelectTeamView> {
   /// 레이아웃 상수
-  static const double _horizontalPadding = 16.0;
-  static const double _verticalPadding = 26.0;
-  static const double _gridSpacing = 12.0;
-  static const double _gridRunSpacing = 20.0;
+  static const double _horizontalPadding = 16.0; // 패딩 줄임
+  static const double _gridSpacing = 12.0; // 간격 줄임
+  static const double _gridRowSpacing = 14.0; // 행 간격 늘림
 
-  /// 고정된 그리드 컬럼 수 (기존 방식으로 돌아감)
+  /// 고정된 그리드 컬럼 수
   static const int _columnCount = 3;
 
   @override
   Widget build(BuildContext context) {
     final vm = context.watch<AuthViewModel>();
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final textTheme = theme.textTheme;
 
     return PopScope(
       canPop: false,
       child: Scaffold(
-        backgroundColor: colorScheme.surface,
-        appBar: TitleHeader(title: '정보입력'),
+        backgroundColor: Colors.white,
+        appBar: AppBar(
+          title: const Text('정보 입력', style: AppTextStyles.subtitle1),
+          centerTitle: true,
+          backgroundColor: Colors.white,
+          foregroundColor: AppColors.black,
+          elevation: 0,
+        ),
         body: SafeArea(
           child: Column(
             children: [
@@ -50,40 +52,61 @@ class _SelectTeamViewState extends State<SelectTeamView> {
                 child: SingleChildScrollView(
                   physics: const ClampingScrollPhysics(),
                   child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: _horizontalPadding,
-                    ),
+                    padding: const EdgeInsets.symmetric(horizontal: _horizontalPadding),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
-                        // 타이틀 섹션
-                        _buildTitle(textTheme),
+                        const SizedBox(height: 25),
+                        // 타이틀
+                        Text(
+                          '어느 구단을 응원하시나요?',
+                          style: AppTextStyles.h3.copyWith(color: AppColors.navy),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 25),
                         // 팀 선택 그리드
                         _buildTeamGrid(vm),
-                        const SizedBox(height: 20),
                       ],
                     ),
                   ),
                 ),
               ),
+
               // 하단 버튼 영역
-              _buildBottomButton(vm),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+                child: Column(
+                  children: [
+                    // 다음 버튼
+                    Container(
+                      width: double.infinity,
+                      height: 56,
+                      child: TextButton(
+                        onPressed: vm.team != null ? widget.onNext : null,
+                        style: TextButton.styleFrom(
+                          backgroundColor: vm.team != null ? AppColors.navy : AppColors.navy5,
+                          foregroundColor: vm.team != null ? Colors.white : AppColors.navy30,
+                          disabledForegroundColor: AppColors.navy30,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                          padding: EdgeInsets.zero,
+                        ),
+                        child: Text('다음', style: AppTextStyles.subtitle2),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+
+                    // iOS 홈 인디케이터
+                    Container(
+                      width: 134,
+                      height: 5,
+                      decoration: BoxDecoration(color: Colors.black, borderRadius: BorderRadius.circular(100)),
+                    ),
+                  ],
+                ),
+              ),
             ],
           ),
         ),
-      ),
-    );
-  }
-
-  /// 타이틀 섹션 위젯
-  Widget _buildTitle(TextTheme textTheme) {
-    return Padding(
-      key: const Key('team_selection_title'),
-      padding: const EdgeInsets.symmetric(vertical: _verticalPadding),
-      child: Text(
-        '어느 구단을 응원하시나요?',
-        style: textTheme.displaySmall,
-        textAlign: TextAlign.center,
       ),
     );
   }
@@ -93,49 +116,88 @@ class _SelectTeamViewState extends State<SelectTeamView> {
     return Padding(
       key: const Key('team_selection_grid'),
       padding: EdgeInsets.zero,
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final double itemWidth =
-              (constraints.maxWidth - (_gridSpacing * (_columnCount - 1))) /
-              _columnCount;
+      child: Column(
+        children: [
+          // 첫 번째 행 (KIA, KT, LG)
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              _buildTeamButtonWithWidth(vm, 'tigers', 0),
+              SizedBox(width: _gridSpacing),
+              _buildTeamButtonWithWidth(vm, 'wiz', 1),
+              SizedBox(width: _gridSpacing),
+              _buildTeamButtonWithWidth(vm, 'twins', 2),
+            ],
+          ),
+          // 첫 번째 행과 두 번째 행 사이 간격 조정
+          SizedBox(height: _gridRowSpacing + 4),
 
-          return Wrap(
-            spacing: _gridSpacing,
-            runSpacing: _gridRunSpacing,
-            alignment: WrapAlignment.start,
-            children:
-                TeamData.teams.map((team) {
-                  final bool isSelected = vm.team == team.name;
+          // 두 번째 행 (NC, SSG, 두산)
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              _buildTeamButtonWithWidth(vm, 'dinos', 3),
+              SizedBox(width: _gridSpacing),
+              _buildTeamButtonWithWidth(vm, 'landers', 4),
+              SizedBox(width: _gridSpacing),
+              _buildTeamButtonWithWidth(vm, 'bears', 5),
+            ],
+          ),
+          // 첫 번째 행과 두 번째 행 사이 간격 조정
+          SizedBox(height: _gridRowSpacing + 4),
 
-                  return SizedBox(
-                    width: itemWidth,
-                    child: TeamButton(
-                      key: Key('team_button_${team.name}'),
-                      team: team,
-                      isSelected: isSelected,
-                      onTap: () => vm.selectTeam(isSelected ? null : team.name),
-                    ),
-                  );
-                }).toList(),
-          );
-        },
+          // 세 번째 행 (롯데, 삼성, 키움)
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              _buildTeamButtonWithWidth(vm, 'giants', 6),
+              SizedBox(width: _gridSpacing),
+              _buildTeamButtonWithWidth(vm, 'lions', 7),
+              SizedBox(width: _gridSpacing),
+              _buildTeamButtonWithWidth(vm, 'heroes', 8),
+            ],
+          ),
+          // 첫 번째 행과 두 번째 행 사이 간격 조정
+          SizedBox(height: _gridRowSpacing + 4),
+
+          // 네 번째 행 (한화)
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              _buildTeamButtonWithWidth(vm, 'eagles', 9),
+              SizedBox(width: _gridSpacing),
+              // 빈 공간 유지
+              Opacity(opacity: 0, child: _buildEmptySpace()),
+              SizedBox(width: _gridSpacing),
+              // 빈 공간 유지
+              Opacity(opacity: 0, child: _buildEmptySpace()),
+            ],
+          ),
+        ],
       ),
     );
   }
 
-  /// 하단 버튼 위젯
-  Widget _buildBottomButton(AuthViewModel vm) {
-    return Padding(
-      key: const Key('team_selection_bottom'),
-      padding: const EdgeInsets.fromLTRB(
-        _horizontalPadding,
-        0,
-        _horizontalPadding,
-        8,
-      ),
-      child: PrimaryButton.next(
-        onTap: widget.onNext,
-        isEnabled: vm.team != null,
+  Widget _buildEmptySpace() {
+    return SizedBox(
+      width: (MediaQuery.of(context).size.width - (_horizontalPadding * 2) - (_gridSpacing * 2)) / 3,
+      height: TeamButton.maxSize + 30, // 버튼 높이 + 텍스트 영역
+    );
+  }
+
+  Widget _buildTeamButtonWithWidth(AuthViewModel vm, String code, int index, {bool isHighlighted = false}) {
+    final team = TeamData.getByCode(code);
+    if (team == null) return SizedBox.shrink();
+
+    final width = (MediaQuery.of(context).size.width - (_horizontalPadding * 2) - (_gridSpacing * 2)) / 3;
+
+    return SizedBox(
+      width: width,
+      child: TeamButton(
+        key: Key('team_button_$code'),
+        team: team,
+        isSelected: vm.team == code,
+        onTap: () => vm.selectTeam(vm.team == code ? null : code),
       ),
     );
   }

--- a/lib/view/auth/widgets/welcome_view.dart
+++ b/lib/view/auth/widgets/welcome_view.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:seungyo/constants/team_data.dart';
+import 'package:seungyo/theme/app_colors.dart';
+import 'package:seungyo/theme/app_text_styles.dart';
 import 'package:seungyo/viewmodel/auth_vm.dart';
 
 class WelcomeView extends StatefulWidget {
@@ -12,7 +15,7 @@ class WelcomeView extends StatefulWidget {
 }
 
 class _WelcomeViewState extends State<WelcomeView> {
-  int _countdown = 3;
+  int _countdown = 4;
 
   @override
   void initState() {
@@ -33,50 +36,116 @@ class _WelcomeViewState extends State<WelcomeView> {
   @override
   Widget build(BuildContext context) {
     final vm = context.watch<AuthViewModel>();
-    final team = vm.team ?? '구단';
-    final nickname = vm.nickname ?? '승요';
+    final teamCode = vm.team ?? 'bears';
+    final teamName = vm.teamName ?? 'LG 트윈스';
+    final nickname = vm.nickname ?? 'LG승리요정';
 
     return PopScope(
       canPop: false,
       child: Scaffold(
+        backgroundColor: Colors.white,
         appBar: AppBar(
-          title: const Text('회원가입 완료'),
+          title: const Text('회원가입 완료', style: AppTextStyles.subtitle1),
           centerTitle: true,
           backgroundColor: Colors.white,
-          foregroundColor: Colors.black,
+          foregroundColor: AppColors.black,
           elevation: 0,
         ),
         body: SafeArea(
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const SizedBox(height: 64),
-                  const SizedBox(height: 16),
-                  Text(
-                    '$team 승요\n$nickname님!',
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.titleLarge,
+          bottom: false,
+          child: Column(
+            children: [
+              // 메인 콘텐츠 영역
+              Expanded(
+                child: Container(
+                  width: double.infinity,
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      // 팀 로고 및 정보
+                      Column(
+                        children: [
+                          // 팀 로고
+                          Container(
+                            width: 100,
+                            height: 100,
+                            decoration: BoxDecoration(
+                              color: AppColors.navy5,
+                              shape: BoxShape.circle,
+                              border: Border.all(color: AppColors.gray30, width: 1),
+                            ),
+                            child: ClipOval(
+                              child: Padding(
+                                padding: const EdgeInsets.all(20.0),
+                                child: Image.asset(TeamData.getByCode(teamCode)?.emblem ?? '', fit: BoxFit.contain),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+
+                          // 팀 이름
+                          Text(
+                            '$teamName 승요의',
+                            style: AppTextStyles.subtitle1.copyWith(color: AppColors.navy),
+                            textAlign: TextAlign.center,
+                          ),
+
+                          // 닉네임 표시 (하이라이트 효과 적용)
+                          const SizedBox(height: 3),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              // 닉네임 (글로우 효과)
+                              Container(
+                                padding: const EdgeInsets.symmetric(horizontal: 4),
+                                decoration: BoxDecoration(
+                                  boxShadow: [
+                                    BoxShadow(color: AppColors.mint.withOpacity(0.3), blurRadius: 10, spreadRadius: 1),
+                                  ],
+                                ),
+                                child: Text(
+                                  nickname,
+                                  style: AppTextStyles.h3.copyWith(color: AppColors.navy, fontWeight: FontWeight.bold),
+                                ),
+                              ),
+                              // '님!' 텍스트
+                              Text(
+                                '님!',
+                                style: AppTextStyles.h3.copyWith(color: AppColors.navy, fontWeight: FontWeight.bold),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+
+                      const SizedBox(height: 35),
+
+                      // "승리의 기록을 남기러 가볼까요?" 텍스트
+                      Text(
+                        '승리의 기록을\n남기러 가볼까요?',
+                        textAlign: TextAlign.center,
+                        style: AppTextStyles.h1.copyWith(color: AppColors.navy),
+                      ),
+
+                      // 카운트다운 표시
+                      const SizedBox(height: 20),
+                      Text(
+                        '${_countdown - 1}초 후 자동으로 이동합니다',
+                        style: AppTextStyles.body2.copyWith(color: AppColors.gray70),
+                      ),
+                    ],
                   ),
-                  const SizedBox(height: 35),
-                  const Text(
-                    '승리의 기록을\n남기러 가볼까요?',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(fontSize: 16),
-                  ),
-                  const SizedBox(height: 50),
-                  Text(
-                    '${_countdown}sec',
-                    style: const TextStyle(
-                      fontSize: 24,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ],
+                ),
               ),
-            ),
+
+              // 하단 홈 인디케이터
+              Container(
+                width: 134,
+                height: 5,
+                margin: const EdgeInsets.only(bottom: 8),
+                decoration: BoxDecoration(color: Colors.black, borderRadius: BorderRadius.circular(100)),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/viewmodel/auth_vm.dart
+++ b/lib/viewmodel/auth_vm.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:seungyo/constants/team_data.dart';
 import 'package:seungyo/repository/auth_repository.dart';
 
 class AuthViewModel extends ChangeNotifier {
@@ -12,6 +13,13 @@ class AuthViewModel extends ChangeNotifier {
   String? get team => _team;
 
   String? get nickname => _nickname;
+
+  // team 코드에 해당하는 팀 이름을 반환하는 getter
+  String? get teamName {
+    if (_team == null) return null;
+    final teamData = TeamData.getByCode(_team!);
+    return teamData?.name;
+  }
 
   void selectTeam(String? team) {
     _team = team;
@@ -37,8 +45,7 @@ class AuthViewModel extends ChangeNotifier {
 
   Future<bool> handleDoubleBackPress(BuildContext context) async {
     final now = DateTime.now();
-    if (_lastBackPressTime == null ||
-        now.difference(_lastBackPressTime!) > const Duration(seconds: 2)) {
+    if (_lastBackPressTime == null || now.difference(_lastBackPressTime!) > const Duration(seconds: 2)) {
       _lastBackPressTime = now;
       Fluttertoast.showToast(msg: '뒤로 버튼을 한 번 더 누르면 앱이 종료됩니다');
       return false;


### PR DESCRIPTION
feat: 닉네임 입력 화면 개선 및 유효성 검사 추가

- 피그마 디자인에 맞춰 닉네임 입력 화면 UI 개선
- 닉네임 길이 제한(2~10글자) 기능 구현
- 닉네임 유효성에 따른 버튼 활성화/비활성화 상태 관리
- 유효성 검사 결과에 따른 피드백 메시지 표시
  - 2글자 미만: 메시지 없음, 버튼 비활성화
  - 2~10글자: "사용 가능한 닉네임이에요." 메시지와 체크 아이콘 표시
  - 10글자 초과: "닉네임은 최대 10글자까지 가능해요." 메시지와 오류 아이콘 표시
- 버튼 스타일 개선: 유효한 닉네임일 때 네이비 배경과 흰색 텍스트

이 변경으로 사용자에게 더 직관적이고 명확한 피드백을 제공하여 UX 개선